### PR TITLE
Fix video removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ Each download command has a `-D`/`--delete-after` option, which makes the script
 ### In Python
 
 ```python
+from os.path import expanduser
 from youtube_unofficial import YouTube
 
-yt = YouTube(cookies=expanduser('~/my-cookies-file.txt'), logged_in=True)
+yt = YouTube(cookies_path=expanduser('~/my-cookies-file.txt'), logged_in=True)
 
 # Clear watch history
 yt.clear_watch_history()
 
 # Remove a single video ID from Watch Later queue
-yt.remove_video_id_from_watch_later(video_id)
+yt.remove_set_video_id_from_playlist('WL', video_id)
 
 # Clear entire Watch Later queue
 yt.clear_watch_later()

--- a/youtube_unofficial/__init__.py
+++ b/youtube_unofficial/__init__.py
@@ -130,19 +130,13 @@ class YouTube(DownloadMixin):
                                             'playlistId':
                                             playlist_id,
                                             'actions': [{
-                                                'setVideoId':
+                                                'removedVideoId':
                                                 set_video_id,
                                                 'action':
-                                                'ACTION_REMOVE_VIDEO'
+                                                'ACTION_REMOVE_VIDEO_BY_VIDEO_ID'
                                             }],
                                             'params':
-                                            'CAE%3D',
-                                            'clientActions': [{
-                                                'playlistRemoveVideosAction': {
-                                                    'setVideoIds':
-                                                    [set_video_id]
-                                                }
-                                            }]
+                                            'CAE%3D'
                                         }
                                     }),
                                     'csn':


### PR DESCRIPTION
This pull request fixes video removal and corrects the Python instructions.

Currently, the following message is returned when a video is removed:
`{'code': 'ERROR', 'error': 'This functionality is not available right now. Please try again later.'}`

Looking at the JSON request when a video is removed in the browser, the action `ACTION_REMOVE_VIDEO` is used but no `clientActions` are included. After removing `clientActions` there was still an error, changing the action to `ACTION_REMOVE_VIDEO_BY_VIDEO_ID` which has more Google results appears to work.